### PR TITLE
Fix a Typoed Class Name

### DIFF
--- a/src/main/Environments.php
+++ b/src/main/Environments.php
@@ -19,7 +19,7 @@ final class Environments
     {
         $e = strtolower($env);
         if (!in_array($e, [self::PROD, self::SANDBOX], true)) {
-            throw new InvalidApiEnvironemnt($env);
+            throw new InvalidApiEnvironment($env);
         }
 
         return $e;

--- a/test/EnvironmentsTest.php
+++ b/test/EnvironmentsTest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace PMG\BingAds;
+
+use PMG\BingAds\Exception\InvalidApiEnvironment;
+
+class EnvironmentsTest extends TestCase
+{
+    public function testValidEnvironmentReturnsFromValidate()
+    {
+        $env = Environments::validate(Environments::PROD);
+
+        $this->assertSame(Environments::PROD, $env);
+    }
+
+    public function testInvalidEnvironmntThrowInValidate()
+    {
+        $this->expectException(InvalidApiEnvironment::class);
+        Environments::validate('nope');
+    }
+}


### PR DESCRIPTION
And add some tests to make sure that doesn't happen again.